### PR TITLE
remove overflow-x rule that causes horizontal scrollbars on windows

### DIFF
--- a/docs-src/src/theme/static/style.css
+++ b/docs-src/src/theme/static/style.css
@@ -34,7 +34,6 @@ div.related ul {
 }
 
 .breadcrumbs {
-  overflow-x: scroll;
   background: #fafafa;
   border-bottom: 1px solid #ddd;
 }

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -34,7 +34,6 @@ div.related ul {
 }
 
 .breadcrumbs {
-  overflow-x: scroll;
   background: #fafafa;
   border-bottom: 1px solid #ddd;
 }


### PR DESCRIPTION
i guess this rule is from the regular sphinx stylesheet, causes horizontal scroll bars in windows chrome.