### PR TITLE
Buffer support for Node request body

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
     - texlive-latex-recommended
     - latex-xcolor
     - lmodern
+    - latexmk
 
 node_js:
 - '5.5'

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -27,7 +27,6 @@
 # needs_sphinx = '1.0'
 
 import os
-import sys
 import subprocess
 from datetime import date
 

--- a/docs/src/theme/layout.html
+++ b/docs/src/theme/layout.html
@@ -1,7 +1,5 @@
 {% extends "sphinxdoc/layout.html" %}
 
-{% set css_files = css_files + ['_static/bootstrap/css/bootstrap.min.css', '_static/overrides.css'] %}
-
 {%- from "relbar.html" import relbar_top with context %}
 
 {% block htmltitle %}
@@ -36,6 +34,8 @@
 <meta property="og:url" content="http://hyper.wickstrom.tech" />
 <meta property="og:image" content="http://hyper.wickstrom.tech/_static/icon-large.png" />
 
+<link rel="stylesheet" href="{{ pathto('_static/overrides.css', 1) }}">
+<link rel="stylesheet" href="{{ pathto('_static/bootstrap/css/bootstrap.min.css', 1) }}">
 <link href="https://fonts.googleapis.com/css?family=Fira+Mono|Fira+Sans:400,400i,600" rel="stylesheet">
 {% endblock %}
 

--- a/docs/src/topic-guides/FormSerialization.purs
+++ b/docs/src/topic-guides/FormSerialization.purs
@@ -21,6 +21,7 @@ import Hyper.Node.Server (defaultOptionsWithLogging, runServer)
 import Hyper.Request (class ReadableBody, class Request, getRequestData)
 import Hyper.Response (class Response, class ResponseWritable, ResponseEnded, StatusLineOpen, closeHeaders, respond, writeStatus)
 import Hyper.Status (statusBadRequest, statusMethodNotAllowed)
+import Node.Buffer (BUFFER)
 import Node.HTTP (HTTP)
 
 -- start snippet datatypes
@@ -88,7 +89,7 @@ onPost =
                      <> show beers <> " beers coming up!\n")
 -- end snippet onPost
 
-main :: forall e. Eff (http :: HTTP, console :: CONSOLE, exception :: EXCEPTION, avar :: AVAR | e) Unit
+main :: forall e. Eff (http :: HTTP, console :: CONSOLE, exception :: EXCEPTION, avar :: AVAR, buffer :: BUFFER | e) Unit
 main =
   let
     router =

--- a/docs/src/topic-guides/ReadBody.purs
+++ b/docs/src/topic-guides/ReadBody.purs
@@ -14,6 +14,7 @@ import Hyper.Node.Server (defaultOptionsWithLogging, runServer)
 import Hyper.Request (class ReadableBody, getRequestData, readBody)
 import Hyper.Response (class Response, class ResponseWritable, ResponseEnded, StatusLineOpen, closeHeaders, respond, writeStatus)
 import Hyper.Status (statusBadRequest, statusMethodNotAllowed)
+import Node.Buffer (BUFFER)
 import Node.HTTP (HTTP)
 
 onPost
@@ -41,7 +42,7 @@ onPost =
       :*> respond ("You said: " <> msg)
 -- end snippet onPost
 
-main :: forall e. Eff (http :: HTTP, console :: CONSOLE, exception :: EXCEPTION, avar :: AVAR | e) Unit
+main :: forall e. Eff (http :: HTTP, console :: CONSOLE, exception :: EXCEPTION, avar :: AVAR, buffer :: BUFFER | e) Unit
 main =
   let
     router =

--- a/examples/FormParser.purs
+++ b/examples/FormParser.purs
@@ -18,12 +18,13 @@ import Hyper.Node.Server (defaultOptionsWithLogging, runServer)
 import Hyper.Request (getRequestData)
 import Hyper.Response (closeHeaders, contentType, respond, writeStatus)
 import Hyper.Status (statusBadRequest, statusMethodNotAllowed, statusOK)
+import Node.Buffer (BUFFER)
 import Node.HTTP (HTTP)
 import Text.Smolder.HTML (button, form, input, label, p)
 import Text.Smolder.Markup (text, (!))
 import Text.Smolder.Renderer.String (render)
 
-main :: forall e. Eff (http :: HTTP, console :: CONSOLE, exception :: EXCEPTION, avar :: AVAR | e) Unit
+main :: forall e. Eff (http :: HTTP, console :: CONSOLE, exception :: EXCEPTION, avar :: AVAR, buffer :: BUFFER | e) Unit
 main =
   let
     -- A view function that renders the name form.

--- a/src/Hyper/Request.purs
+++ b/src/Hyper/Request.purs
@@ -33,8 +33,8 @@ class Request req m where
 class Request req m <= BaseRequest req m
 
 -- | A ReadableBody instance reads the request body for a specific body
--- | reader type.
-class ReadableBody req m b | req -> b where
+-- | type.
+class ReadableBody req m b where
   readBody
     :: forall res c
      . Middleware


### PR DESCRIPTION
@rightfold: Thought I'd break the changes we discussed in #11 up into smaller PRs, so here's just the Buffer support. The `String` instance we had before now uses the same `readBodyAsBuffer` as the `Buffer` instance, which means the `BUFFER` effect spreads all over in existing code using `readBody`. :disappointed:  I'm OK with that for now, though. We can provide some effect alias type for convenience.

I'm thankful for any feedback!