### PR TITLE
Fix #44: runServer now uses runAff instead of launchAff.

### DIFF
--- a/src/Hyper/Node/Server.purs
+++ b/src/Hyper/Node/Server.purs
@@ -17,7 +17,7 @@ import Node.Buffer as Buffer
 import Node.HTTP as HTTP
 import Node.Stream as Stream
 import Control.IxMonad (ipure, (:*>), (:>>=))
-import Control.Monad.Aff (Aff, launchAff, makeAff)
+import Control.Monad.Aff (Aff, launchAff, makeAff, runAff)
 import Control.Monad.Aff.AVar (putVar, takeVar, modifyVar, makeVar', AVAR, makeVar)
 import Control.Monad.Aff.Class (class MonadAff, liftAff)
 import Control.Monad.Eff (Eff)
@@ -250,8 +250,7 @@ runServer' options components runM middleware = do
                  , response: HttpResponse response
                  , components: components
                  }
-      in catchException options.onRequestError (void (launchAff (runM (evalMiddleware middleware conn))))
-
+      in conn # evalMiddleware middleware # runM # runAff options.onRequestError (const $ pure unit) # void
 
 runServer
   :: forall e c c'.


### PR DESCRIPTION
After testing it a bit more, it turns out it doesn't catch async invalid queries after all (#43), so they will certainly require their own fix. However, it does catch properly typed `Aff` errors, for example failed database queries, unlike the previous version.

Please let me know if there's a certain style the code should follow or the like.