### PR TITLE
Fix InMemory put and delete bug

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -32,7 +32,9 @@
     "purescript-http-methods": "^3.0.0",
     "purescript-indexed-monad": "^0.3.0",
     "purescript-smolder": "^7.0.0",
-    "purescript-aff": "^4.0.0"
+    "purescript-aff": "^4.0.0",
+    "purescript-random": "^3.0.0",
+    "purescript-refs": "^3.0.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^3.0.0",

--- a/examples/Sessions.purs
+++ b/examples/Sessions.purs
@@ -3,12 +3,13 @@ module Examples.Sessions where
 import Prelude
 import Control.IxMonad ((:*>), (:>>=))
 import Control.Monad.Aff (launchAff)
-import Control.Monad.Aff.AVar (AVAR)
 import Control.Monad.Aff.Console (log)
 import Control.Monad.Eff (Eff)
 import Control.Monad.Eff.Class (liftEff)
 import Control.Monad.Eff.Console (CONSOLE)
 import Control.Monad.Eff.Exception (EXCEPTION)
+import Control.Monad.Eff.Random (RANDOM)
+import Control.Monad.Eff.Ref (REF)
 import Data.Maybe (Maybe(..))
 import Data.MediaType.Common (textHTML)
 import Hyper.Cookies (cookies)
@@ -23,9 +24,9 @@ import Node.HTTP (HTTP)
 
 newtype MySession = MySession { userId :: Int }
 
-main :: forall e. Eff (exception :: EXCEPTION, avar :: AVAR, console :: CONSOLE, http :: HTTP | e) Unit
+main :: forall e. Eff (exception :: EXCEPTION, ref :: REF, console :: CONSOLE, http :: HTTP, random ::RANDOM | e) Unit
 main = void $ launchAff do
-  store <- newInMemorySessionStore
+  store <- liftEff newInMemorySessionStore
   liftEff (runServer defaultOptionsWithLogging (components store) app)
   where
     components store =

--- a/src/Hyper/Node/Session/InMemory.js
+++ b/src/Hyper/Node/Session/InMemory.js
@@ -1,0 +1,5 @@
+"use strict";
+
+exports.generatedSessionID = function() {
+  return String((new Date()).getTime() + Math.random());
+};

--- a/src/Hyper/Node/Session/InMemory.purs
+++ b/src/Hyper/Node/Session/InMemory.purs
@@ -3,7 +3,7 @@ module Hyper.Node.Session.InMemory where
 import Prelude
 
 import Control.Monad.Aff (Aff)
-import Control.Monad.Aff.AVar (AVAR, AVar, makeVar, putVar, readVar)
+import Control.Monad.Aff.AVar (AVAR, AVar, makeVar, putVar, readVar, takeVar)
 import Control.Monad.Aff.Class (class MonadAff, liftAff)
 import Control.Monad.Aff.Console (CONSOLE, log)
 import Data.Map (Map)
@@ -31,12 +31,12 @@ instance sessionStoreInMemorySessionStore :: ( Monad m
   put (InMemorySessionStore var) id session = do
     liftAff do
       log ("Saving session: " <> unwrap id)
-      Map.insert id session <$> readVar var >>= flip putVar var
+      Map.insert id session <$> takeVar var >>= flip putVar var
 
   delete (InMemorySessionStore var) id = do
     liftAff do
       log ("Deleting session: " <> unwrap id)
-      Map.delete id <$> readVar var >>= flip putVar var
+      Map.delete id <$> takeVar var >>= flip putVar var
 
 newInMemorySessionStore
   :: forall e session

--- a/src/Hyper/Node/Session/InMemory.purs
+++ b/src/Hyper/Node/Session/InMemory.purs
@@ -2,43 +2,47 @@ module Hyper.Node.Session.InMemory where
 
 import Prelude
 
-import Control.Monad.Aff (Aff)
-import Control.Monad.Aff.AVar (AVAR, AVar, makeVar, putVar, readVar, takeVar)
-import Control.Monad.Aff.Class (class MonadAff, liftAff)
-import Control.Monad.Aff.Console (CONSOLE, log)
+import Control.Monad.Eff.Class (class MonadEff, liftEff)
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Console (CONSOLE, log)
+import Control.Monad.Eff.Random (RANDOM)
+import Control.Monad.Eff.Ref (REF, Ref, modifyRef, newRef, readRef)
 import Data.Map (Map)
 import Data.Map as Map
 import Data.Newtype (unwrap)
 import Hyper.Session (class SessionStore, SessionID(..))
 
-data InMemorySessionStore session = InMemorySessionStore (AVar (Map SessionID session))
+data InMemorySessionStore session = InMemorySessionStore (Ref (Map SessionID session))
+
+foreign import generatedSessionID ::forall eff. Eff (random :: RANDOM | eff) String
 
 instance sessionStoreInMemorySessionStore :: ( Monad m
-                                             , MonadAff (avar :: AVAR, console :: CONSOLE | e) m
+                                             , MonadEff (ref:: REF, console :: CONSOLE, random :: RANDOM | e) m
                                              )
                                           => SessionStore
                                             (InMemorySessionStore session)
                                             m
                                             session where
-  newSessionID _ =
-    pure (SessionID "new-id")
+  newSessionID _ = do
+    id <- liftEff generatedSessionID
+    pure (SessionID id)
 
   get (InMemorySessionStore var) id =
-    liftAff do
+    liftEff do
       log ("Looking up session: " <> show (unwrap id))
-      Map.lookup id <$> readVar var
+      Map.lookup id <$> readRef var
 
   put (InMemorySessionStore var) id session = do
-    liftAff do
+    liftEff do
       log ("Saving session: " <> unwrap id)
-      Map.insert id session <$> takeVar var >>= flip putVar var
+      modifyRef var $ Map.insert id session
 
   delete (InMemorySessionStore var) id = do
-    liftAff do
+    liftEff do
       log ("Deleting session: " <> unwrap id)
-      Map.delete id <$> takeVar var >>= flip putVar var
+      modifyRef var $ Map.delete id
 
 newInMemorySessionStore
   :: forall e session
-   . Aff ( avar ∷ AVAR | e ) (InMemorySessionStore session)
-newInMemorySessionStore = InMemorySessionStore <$> makeVar Map.empty
+   . Eff ( ref∷ REF | e ) (InMemorySessionStore session)
+newInMemorySessionStore = InMemorySessionStore <$> newRef Map.empty


### PR DESCRIPTION
If the `AVar` is already filled, it will be queued until the value is emptied, so I change `readVar` to `takeVar`.