### PR TITLE
Optionally replace `+` in `parseUrlencoded`

### DIFF
--- a/docs/src/topic-guides/forms.rst
+++ b/docs/src/topic-guides/forms.rst
@@ -1,11 +1,13 @@
 *****
-Forms
+Parsing incomming data
 *****
 
-When working with form data, we often want to serialize and deserialize
-forms as custom data types, instead of working with the key-value pairs
-directly. The ``ToForm`` and ``FromForm`` type classes abstracts
-serialization and deserialization to form data, respectively.
+Hyper doesn't provide any built in validation framework, but it makes
+it quite easy for you to do the job by providing simple data type `Hyper.Form.Form`
+which represent incomming `GET` or `POST` data. There is also some plumbing
+implemented for parsing incomming urlencoded data into `Form` value.
+
+Let's look at simple example in which we are going to do some simple validation of incoming data.
 
 We first declare our data types, and some instance which we will need
 later.
@@ -15,18 +17,19 @@ later.
    :start-after: start snippet datatypes
    :end-before: end snippet datatypes
 
-In this example we will only deserialize forms, and thus we only need
-the ``FromForm`` instance.
+In this example we use really simple approach to validation which only reports first encountered
+error:
 
 .. literalinclude:: FormSerialization.purs
    :language: haskell
    :start-after: start snippet parsing
    :end-before: end snippet parsing
 
-Now we are ready to write our handler. We use ``parseFromForm`` to get a
-value of type ``Either String Order``, where the ``String`` explains
-parsing errors. By pattern matching using record field puns, we extract
-the ``beers`` and ``meal`` values, and respond based on those values.
+Now we are ready to write our handler. We use ``parseOrder`` to get a
+value of type ``Either String Order`` from ``Either String Form``,
+where the ``String`` explains parsing errors. By pattern matching using
+record field puns, we extract the ``beers`` and ``meal`` values, and respond
+based on those values.
 
 .. literalinclude:: FormSerialization.purs
    :language: haskell

--- a/src/Hyper/Form/Urlencoded.purs
+++ b/src/Hyper/Form/Urlencoded.purs
@@ -1,33 +1,48 @@
 -- | Parser for the `application/x-www-form-urlencoded` format, commonly used
 -- | for query strings and POST request bodies.
 module Hyper.Form.Urlencoded
-       ( parseUrlencoded
+       ( defaultOptions
+       , Options
+       , parseUrlencoded
        ) where
 
 import Prelude
+
 import Control.Monad.Error.Class (throwError)
 import Data.Array as Array
 import Data.Either (Either)
 import Data.Maybe (Maybe(Just, Nothing))
-import Data.String (split, joinWith, Pattern(Pattern))
+import Data.String (Pattern(..), Replacement(..), joinWith, replaceAll, split)
 import Data.Traversable (sequence)
 import Data.Tuple (Tuple(Tuple))
 import Global (decodeURIComponent)
 
-toTuple :: Array String -> Either String (Tuple String (Maybe String))
-toTuple kv =
+toTuple :: Options -> Array String -> Either String (Tuple String (Maybe String))
+toTuple opts kv =
   case kv of
     [key] ->
       pure (Tuple (decodeURIComponent key) Nothing)
     [key, value] ->
-      pure (Tuple (decodeURIComponent key) (Just (decodeURIComponent value)))
+      let
+        value' =
+          if opts.replacePlus
+            then
+              replaceAll (Pattern "+") (Replacement " ") value
+            else
+              value
+      in
+        pure (Tuple (decodeURIComponent key) (Just (decodeURIComponent value')))
     parts ->
       throwError ("Invalid form key-value pair: " <> joinWith " " parts)
 
+type Options = { replacePlus :: Boolean }
 
-parseUrlencoded :: String → Either String (Array (Tuple String (Maybe String)))
-parseUrlencoded = split (Pattern "&")
+defaultOptions :: Options
+defaultOptions = { replacePlus: true }
+
+parseUrlencoded :: Options -> String -> Either String (Array (Tuple String (Maybe String)))
+parseUrlencoded opts = split (Pattern "&")
                   >>> Array.filter (_ /= "")
                   >>> map (split (Pattern "="))
-                  >>> map toTuple
+                  >>> map (toTuple opts)
                   >>> sequence

--- a/src/Hyper/Node/Server/Options.purs
+++ b/src/Hyper/Node/Server/Options.purs
@@ -24,6 +24,7 @@ type Options e =
   , port :: Port
   , onListening :: Hostname -> Port -> Eff (http :: HTTP | e) Unit
   , onRequestError :: Error -> Eff (http :: HTTP | e) Unit
+  , replacePlus :: Boolean
   }
 
 
@@ -33,6 +34,7 @@ defaultOptions =
   , port: Port 3000
   , onListening: const (const (pure unit))
   , onRequestError: const (pure unit)
+  , replacePlus: true
   }
 
 

--- a/src/Hyper/Request.purs
+++ b/src/Hyper/Request.purs
@@ -12,16 +12,18 @@ module Hyper.Request
   ) where
 
 import Prelude
+
 import Data.Array as Array
-import Data.String as String
 import Data.Bifunctor (lmap)
 import Data.Either (Either)
 import Data.HTTP.Method (CustomMethod, Method)
 import Data.Lazy (Lazy)
 import Data.Maybe (Maybe, fromMaybe)
 import Data.StrMap (StrMap)
+import Data.String as String
 import Data.Tuple (Tuple)
 import Hyper.Conn (Conn)
+import Hyper.Form.Urlencoded (Options) as Urlencoded
 import Hyper.Form.Urlencoded (parseUrlencoded)
 import Hyper.Middleware (Middleware)
 
@@ -38,14 +40,14 @@ type ParsedUrl =
   , query :: Either String (Array (Tuple String (Maybe String)))
   }
 
-parseUrl :: String -> ParsedUrl
-parseUrl url =
+parseUrl :: Urlencoded.Options -> String -> ParsedUrl
+parseUrl opts url =
   let
     idx = fromMaybe (String.length url) $ String.indexOf (String.Pattern "?") url
     rawPath = String.take idx url
     rawQuery = String.drop (idx + 1) url
     path = Array.filter (_ /= "") $ String.split (String.Pattern "/") rawPath
-    query = lmap (const rawQuery) $ parseUrlencoded rawQuery
+    query = lmap (const rawQuery) $ parseUrlencoded opts rawQuery
   in
     {path, query}
 

--- a/src/Hyper/Test/TestServer.purs
+++ b/src/Hyper/Test/TestServer.purs
@@ -1,7 +1,5 @@
 module Hyper.Test.TestServer where
 
-import Data.String as String
-import Data.StrMap as StrMap
 import Control.Alt ((<|>))
 import Control.Applicative (pure)
 import Control.IxMonad (ipure, (:*>), (:>>=))
@@ -19,7 +17,10 @@ import Data.Monoid (mempty, class Monoid)
 import Data.Newtype (class Newtype, unwrap)
 import Data.Semigroup (class Semigroup, (<>))
 import Data.StrMap (StrMap)
+import Data.StrMap as StrMap
+import Data.String as String
 import Hyper.Conn (Conn)
+import Hyper.Form.Urlencoded (defaultOptions) as Urlencoded
 import Hyper.Header (Header)
 import Hyper.Middleware (lift')
 import Hyper.Middleware.Class (getConn, modifyConn)
@@ -56,7 +57,7 @@ instance requestTestRequest :: Monad m => Request TestRequest m where
   getRequestData =
     getConn :>>= \{ request: TestRequest r } ->
     ipure { url: r.url
-          , parsedUrl: defer \_ -> parseUrl r.url
+          , parsedUrl: defer \_ -> parseUrl Urlencoded.defaultOptions r.url
           , contentLength: Just (String.length r.body)
           , method: r.method
           , headers: r.headers

--- a/test/Hyper/FormSpec.purs
+++ b/test/Hyper/FormSpec.purs
@@ -1,6 +1,7 @@
 module Hyper.FormSpec where
 
 import Prelude
+
 import Control.Monad.Aff (Aff)
 import Control.Monad.Eff.Exception (error)
 import Control.Monad.Error.Class (throwError)
@@ -10,6 +11,7 @@ import Data.Maybe (Maybe(..), fromMaybe)
 import Data.StrMap (singleton)
 import Data.Tuple (Tuple(Tuple), fst)
 import Hyper.Form (Form(Form), parseForm)
+import Hyper.Form.Urlencoded (defaultOptions) as Urlencoded
 import Hyper.Middleware (runMiddleware)
 import Hyper.Test.TestServer (TestRequest(TestRequest))
 import Test.Spec (Spec, it, describe)
@@ -59,7 +61,7 @@ spec =
   where
     runParseForm body contentType =
       runMiddleware
-      parseForm
+      (parseForm Urlencoded.defaultOptions)
       { request: TestRequest { method: Left GET
                              , body: body
                              , url: ""

--- a/test/Hyper/FormSpec.purs
+++ b/test/Hyper/FormSpec.purs
@@ -28,11 +28,11 @@ spec :: forall e. Spec e Unit
 spec =
   describe "Hyper.Form" do
     it "parses key without value" do
-      form <- runParseForm "foo" Nothing
+      form <- runParseForm "foo" id
       form `shouldEqual` (Form [Tuple "foo" Nothing])
 
     it "parses multiple keys without values" do
-      form <- runParseForm "foo&foo&bar&foo" Nothing
+      form <- runParseForm "foo&foo&bar&foo" id
       form `shouldEqual` (Form [ Tuple "foo" Nothing
                                , Tuple "foo" Nothing
                                , Tuple "bar" Nothing
@@ -40,15 +40,19 @@ spec =
                                ])
 
     it "parses key and value" do
-      form <- runParseForm "foo=bar" Nothing
+      form <- runParseForm "foo=bar" id
       form `shouldEqual` (Form [Tuple "foo" (Just "bar")])
 
     it "handles percent-encoding" do
-      form <- runParseForm "foo=%62%61%72" Nothing
+      form <- runParseForm "foo=%62%61%72" id
       form `shouldEqual` (Form [Tuple "foo" (Just "bar")])
 
+    it "handles plus replacing" do
+      form <- runParseForm "foo=b+r" _{ replacePlus = true }
+      form `shouldEqual` (Form [Tuple "foo" (Just "b r")])
+
     it "parses multiple keys and values" do
-      form <- runParseForm "foo=bar&baz=quux&a=1&b=2" Nothing
+      form <- runParseForm "foo=bar&baz=quux&a=1&b=2" id
       form `shouldEqual` (Form [ Tuple "foo" (Just "bar")
                                , Tuple "baz" (Just "quux")
                                , Tuple "a" (Just "1")
@@ -56,12 +60,12 @@ spec =
                                ])
 
     it "fails to parse request body as a form when invalid" $ expectError $
-      runParseForm "foo=bar=baz" Nothing
+      runParseForm "foo=bar=baz" id
 
   where
-    runParseForm body contentType =
+    runParseForm body opts =
       runMiddleware
-      (parseForm Urlencoded.defaultOptions)
+      (parseForm Urlencoded.defaultOptions { replacePlus = replacePlus })
       { request: TestRequest { method: Left GET
                              , body: body
                              , url: ""
@@ -76,3 +80,5 @@ spec =
       }
       # map fst
       >>= liftEither
+      where
+      { replacePlus, contentType } = opts { contentType: Nothing, replacePlus: false }

--- a/test/Hyper/RequestSpec.purs
+++ b/test/Hyper/RequestSpec.purs
@@ -1,9 +1,11 @@
 module Hyper.RequestSpec where
 
 import Prelude
+
 import Data.Either (Either(..))
 import Data.Maybe (Maybe(..))
 import Data.Tuple.Nested ((/\))
+import Hyper.Form.Urlencoded (defaultOptions) as Urlencoded
 import Hyper.Request (parseUrl)
 import Test.Spec (Spec, it, describe)
 import Test.Spec.Assertions (shouldEqual)
@@ -12,21 +14,21 @@ spec :: forall e. Spec e Unit
 spec =
   describe "Hyper.Request" do
     it "parses the root URL" do
-      let result = parseUrl "/"
+      let result = parseUrl Urlencoded.defaultOptions "/"
       result.path `shouldEqual` []
       result.query `shouldEqual` Right []
 
     it "parses non-root URLs" do
-      let result = parseUrl "/foo/bar"
+      let result = parseUrl Urlencoded.defaultOptions "/foo/bar"
       result.path `shouldEqual` ["foo", "bar"]
       result.query `shouldEqual` Right []
 
     it "parses URLs with query strings" do
-      let result = parseUrl "/foo/bar?abc=def=ghi"
+      let result = parseUrl Urlencoded.defaultOptions "/foo/bar?abc=def=ghi"
       result.path `shouldEqual` ["foo", "bar"]
       result.query `shouldEqual` Left "abc=def=ghi"
 
     it "parses URLs with formatted query strings" do
-      let result = parseUrl "/foo/bar?abc=def&ghi"
+      let result = parseUrl Urlencoded.defaultOptions "/foo/bar?abc=def&ghi"
       result.path `shouldEqual` ["foo", "bar"]
       result.query `shouldEqual` Right ["abc" /\ Just "def", "ghi" /\ Nothing]


### PR DESCRIPTION
This PR provides a way to optionally replace `+` by space in query values before passing them to uri decoding. (I want to reemphasize importance of this change, so I'm coping here my arguments from `purescript-uri` issue).

Without this option hyper user is not able to distinguish `+` from `%2B` in original query as both are decoded to `+` and finally is not able parse text input values containing spaces send by all tested by me modern browsers.

I've tested on two versions of Firefox and Chromium (latest Firefox nightly 59.0a1 (2017-11-20), Chromium 62.0.3202.89 and Firefox 56.0.2) that this form:

```
<!DOCTYPE html>
<html>
<body>
  <form action=".">
    <input name="name with spaces" value="value with spaces" />
    <input type="submit" value="send" />
  </form>
</body>
</html>
```
results in + in queries (so we get "value+with+spaces"). The same behavior is observed when I add explicit enctype=application/x-www-form-urlencoded.

I know that this is not a real argument for discussion, but other libs/tools/frameworks do seem to decode `+` as space in query strings:

   * Haskell http-types (Servant uses http-api-data which uses http-types):

       parseQuery calls two times `urlDecode` with `True` as the first argument:

       https://github.com/aristidb/http-types/blob/master/Network/HTTP/Types/URI.hs#L136

       `urlDecode`:

       https://github.com/aristidb/http-types/blob/master/Network/HTTP/Types/URI.hs#L206


   * Haskell Snap framework decodes `+` in query keys and values to space:

        https://github.com/snapframework/snap-core/blob/master/src/Snap/Internal/Parsing.hs#L368


   * Python3 `urllib.parse` decodes `+` in queries (even in strict mode ;-)):

        https://github.com/python/cpython/blob/3.6/Lib/urllib/parse.py#L697


   * Javascript `query-string` repalces `+` in query keys and values:

       https://github.com/sindresorhus/query-string/blob/master/index.js#L148