### PR TITLE
Add node-buffer as direct dependency.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -24,6 +24,7 @@
     "purescript-http-methods": "^4.0.2",
     "purescript-indexed-monad": "^1.0.0",
     "purescript-media-types": "^4.0.1",
+    "purescript-node-buffer": "^5.0.0",
     "purescript-node-fs-aff": "^6.0.0",
     "purescript-node-http": "^5.0.1",
     "purescript-ordered-collections": "^1.6.1",

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,4 +1,6 @@
-{ name =
+{ sources =
+    [ "src/**/*.purs", "test/**/*.purs" ]
+, name =
     "hyper"
 , dependencies =
     [ "aff"
@@ -13,6 +15,7 @@
     , "http-methods"
     , "indexed-monad"
     , "media-types"
+    , "node-buffer"
     , "node-fs-aff"
     , "node-http"
     , "ordered-collections"


### PR DESCRIPTION
[This change](https://github.com/purescript-node/purescript-node-http/commit/970fd36886225f1d0a62215fcad789c36bea7ba8) broke the build as hyper is not compatible with node-buffer@6, and node-buffer@5 had not been included as a direct dependency.

My naïve guess as to why hyper is not compatible with node-buffer@6 is that some `MutableBuffer` instances need to be added for `MonadEffect m => m` and `MonadAff m => m`. See [the `Node.Buffer` module as of v6](https://github.com/purescript-node/purescript-node-buffer/blob/master/src/Node/Buffer.purs) and notice that a `MutableBuffer` instance exists only for `Effect`. Anyway, that's another issue for another day.

Update: See #84 regarding node-buffer@6.