### PR TITLE
Changes required for node-buffer v6.

### DIFF
--- a/src/Hyper/Node/BasicAuth.purs
+++ b/src/Hyper/Node/BasicAuth.purs
@@ -1,5 +1,7 @@
 module Hyper.Node.BasicAuth where
 
+import Prelude
+import Node.Buffer (Buffer)
 import Node.Buffer as Buffer
 import Control.Monad.Indexed (ibind, ipure)
 import Control.Monad (class Monad, (>>=))
@@ -26,8 +28,9 @@ decodeBase64 ∷ ∀ m c
   .  MonadEffect m
   => String
   → Middleware m c c String
-decodeBase64 encoded =
-  liftEffect (Buffer.fromString encoded Base64 >>= Buffer.toString ASCII)
+decodeBase64 encoded = liftEffect do
+  buffer :: Buffer <- Buffer.fromString encoded Base64
+  Buffer.toString ASCII buffer
 
 
 withAuthentication

--- a/src/Hyper/Node/Server.purs
+++ b/src/Hyper/Node/Server.purs
@@ -124,7 +124,7 @@ readBodyAsBuffer (HttpRequest request _) = do
 instance readableBodyHttpRequestString :: (Monad m, MonadAff m)
                                        => ReadableBody HttpRequest m String where
   readBody =
-    readBody :>>= (liftEffect <<< Buffer.toString UTF8)
+    readBody :>>= (\(buffer :: Buffer) -> liftEffect $ Buffer.toString UTF8 buffer)
 
 instance readableBodyHttpRequestBuffer :: (Monad m, MonadAff m)
                                        => ReadableBody HttpRequest m Buffer where


### PR DESCRIPTION
When the upgrade to node-buffer@6 becomes necessary (due to updated package set, for example), these are the required changes for hyper.