### PR TITLE
Update for new Argonaut major version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,36 +13,35 @@
     "url": "git://github.com/owickstrom/hyper.git"
   },
   "dependencies": {
-    "purescript-aff": "^5.1.1",
+    "purescript-aff": "^5.1.2",
     "purescript-avar": "^3.0.0",
-    "purescript-argonaut": "^6.0.0",
-    "purescript-arrays": "^5.3.0",
-    "purescript-control": "^4.1.0",
+    "purescript-argonaut": "^7.0.0",
+    "purescript-arrays": "^5.3.1",
+    "purescript-control": "^4.2.0",
     "purescript-effect": "^2.0.1",
     "purescript-foldable-traversable": "^4.1.1",
     "purescript-generics-rep": "^6.1.1",
     "purescript-http-methods": "^4.0.2",
-    "purescript-indexed-monad": "^1.1.0",
+    "purescript-indexed-monad": "^1.2.0",
     "purescript-media-types": "^4.0.1",
     "purescript-node-buffer": "^6.0.0",
     "purescript-node-fs-aff": "^6.0.0",
-    "purescript-node-http": "^5.0.1",
+    "purescript-node-http": "^5.0.2",
     "purescript-ordered-collections": "^1.6.1",
     "purescript-proxy": "^3.0.0",
     "purescript-random": "^4.0.0",
-    "purescript-smolder": "^12.0.0",
-    "purescript-strings": "^4.0.1",
+    "purescript-smolder": "^12.3.0",
+    "purescript-strings": "^4.0.2",
     "purescript-transformers": "^4.2.0",
-    "purescript-record-extra": "^3.0.0",
-    "purescript-typelevel-prelude": "^5.0.0"
+    "purescript-record-extra": "^3.0.1",
+    "purescript-typelevel-prelude": "^5.0.2"
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0",
-    "purescript-spec": "^4.0.0",
+    "purescript-spec": "^4.0.1",
     "purescript-spec-discovery": "^4.0.0"
   },
   "resolutions": {
-    "purescript-spec": "^4.0.0",
-    "purescript-typelevel-prelude": "^5.0.0"
+    "purescript-spec": "^4.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,6 @@
   "homepage": "http://hyper.wickstrom.tech",
   "dependencies": {
     "bower-dependency-tree": "^0.1.2",
-    "pulp": "^12.3.0"
+    "pulp": "^15.0.0"
   }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -1,8 +1,5 @@
-let mkPackage =
-      https://raw.githubusercontent.com/purescript/package-sets/psc-0.13.0-20190626/src/mkPackage.dhall sha256:0b197efa1d397ace6eb46b243ff2d73a3da5638d8d0ac8473e8e4a8fc528cf57
-
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.13.3-20190831/packages.dhall sha256:852cd4b9e463258baf4e253e8524bcfe019124769472ca50b316fe93217c3a47
+      https://github.com/purescript/package-sets/releases/download/psc-0.13.8-20200615/packages.dhall sha256:5d0cfad9408c84db0a3fdcea2d708f9ed8f64297e164dc57a7cf6328706df93a
 
 let overrides = {=}
 

--- a/src/Hyper/Node/BasicAuth.purs
+++ b/src/Hyper/Node/BasicAuth.purs
@@ -5,14 +5,10 @@ import Node.Buffer (Buffer)
 import Node.Buffer as Buffer
 import Control.Monad.Indexed (ipure)
 import Control.Monad.Indexed.Qualified as Ix
-import Control.Monad (class Monad, (>>=))
 import Effect.Class (liftEffect, class MonadEffect)
-import Data.Functor ((<$>))
 import Data.Maybe (Maybe(Nothing, Just))
-import Data.Monoid ((<>))
 import Data.String (Pattern(Pattern), split)
 import Data.Tuple (Tuple(Tuple))
-import Data.Unit (Unit)
 import Foreign.Object as Object
 import Hyper.Authentication (setAuthentication)
 import Hyper.Conn (Conn)

--- a/test/Hyper/Node/FileServerSpec.purs
+++ b/test/Hyper/Node/FileServerSpec.purs
@@ -34,7 +34,7 @@ serveFilesAndGet path =
     app = fileServer "test/Hyper/Node/FileServerSpec" on404
 
     on404 = Ix.do
-      body <- liftEffect (Buffer.fromString "Not Found" UTF8)
+      body :: Buffer.Buffer <- liftEffect (Buffer.fromString "Not Found" UTF8)
       writeStatus statusNotFound
       headers []
       respond body


### PR DESCRIPTION
Argonaut's type-class-based codecs [now use typed errors instead of string errors](https://github.com/purescript-contrib/purescript-argonaut-codecs/releases/tag/v7.0.0), so I'm updating affected libraries for compatibility with the new version.

I've bumped dependency versions in the Bower file, but the only major version bump is the `argonaut-codecs` version. Fortunately, this library compiles with both v6.0.0 and v7.0.0 (the new version), so even if Hyper isn't updated when the new package set comes out it will still build with the package set. I also removed the unnecessary dependency resolution for typelevel-eval.

While here, I noticed that the spago.dhall file is using the old format -- `mkPackage` doesn't exist anymore -- so I updated it to use a more recent package set and removed that line. I also noticed that the version of Pulp used in the package.json isn't compatible with the latest PureScript (v0.13.8), so I've updated it.

While verifying that the project still compiles and passes tests with my changes I noticed that the tests fail to compile on v0.13.8 of the compiler due to a missing type annotation. I've added that type annotation so the tests work properly. I also noticed some compiler warnings about duplicate imports, which I've removed.

tldr; dependencies are updated, this library is compatible with the upcoming package set, and it is now also compatible with the latest PureScript tooling.